### PR TITLE
Update runtime but fail to launch

### DIFF
--- a/org.tribler.Tribler.yaml
+++ b/org.tribler.Tribler.yaml
@@ -9,7 +9,7 @@
 id: org.tribler.Tribler
 command: tribler
 runtime: org.kde.Platform
-runtime-version: "5.15"
+runtime-version: "5.15-21.08"
 sdk: org.kde.Sdk
 finish-args:
   - --share=ipc


### PR DESCRIPTION
Hi,
I update the runtime but Tribler fail to launch.

```
andy@localhost:~/Desktop/Flatpak/org.tribler.Tribler> flatpak run org.tribler.Tribler
INFO:__main__:Sentry has been initialised in normal mode
INFO:__main__:Root state dir: /home/andy/.Tribler
INFO:__main__:Running in "normal" mode
INFO:tribler_gui:Load logger config: /home/andy/.Tribler
Error in loading logger config. Using default configs. Error: Unable to configure handler 'console'
INFO:tribler_core.check_os:Check and enable code tracing. Process name: "gui". Log dir: "/home/andy/.Tribler"
INFO:tribler_core.check_os:Enable fault handler: "/home/andy/.Tribler"
INFO:tribler_core.check_os:Check environment
INFO:tribler_core.check_os:Should kill other Tribler instances
INFO:tribler_core.check_os:Old PID: -1. Current PID: 3
INFO:tribler_core.check_os:Check free space
INFO:TriblerApplication:Start Tribler application. Win id: "triblerapp". Sys argv: "['/app/share/tribler/tribler']"
```
