### PR TITLE
Fix for command line args not being forwarded

### DIFF
--- a/org.tribler.Tribler.yaml
+++ b/org.tribler.Tribler.yaml
@@ -45,7 +45,7 @@ modules:
       - type: script
         dest-filename: tribler
         commands:
-          - exec /app/share/tribler/tribler
+          - exec /app/share/tribler/tribler "$@"
   - name: libsodium
     sources:
       - type: archive


### PR DESCRIPTION
This is a partial backport of the required changes for the Tribler 8.0 release to enable command line arguments on the 7.14 Flatpak release.

This PR fixes https://github.com/Tribler/tribler/issues/6483