### PR TITLE
Update org.tribler.Tribler.yaml

### DIFF
--- a/org.tribler.Tribler.yaml
+++ b/org.tribler.Tribler.yaml
@@ -18,6 +18,7 @@ finish-args:
   - --share=network
   - --filesystem=xdg-download                           # Store downloads in the user's download folder
   - --persist=.Tribler                                  # Store the application state
+  - --filesystem=~/.Tribler:create                      # We need to write to the state directory
   - --talk-name=org.kde.StatusNotifierWatcher           # Used for AppIndicator support
   - --env=SSL_CERT_DIR=/etc/ssl/certs
 modules:

--- a/org.tribler.Tribler.yaml
+++ b/org.tribler.Tribler.yaml
@@ -16,10 +16,10 @@ finish-args:
   - --socket=wayland
   - --share=ipc
   - --share=network
-  - --filesystem=xdg-download                           # Store downloads in the user's download folder
-  - --persist=.Tribler                                  # Store the application state
-  - --filesystem=~/.Tribler:create                      # We need to write to the state directory
-  - --talk-name=org.kde.StatusNotifierWatcher           # Used for AppIndicator support
+  - --filesystem=xdg-download                                         # Store downloads in the user's download folder
+  - --filesystem=~/.var/app/org.tribler.Tribler/.Tribler:create       # We need to write to the state directory
+  - --persist=.Tribler                                                # Store the application state
+  - --talk-name=org.kde.StatusNotifierWatcher                         # Used for AppIndicator support
   - --env=SSL_CERT_DIR=/etc/ssl/certs
 modules:
   - shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json


### PR DESCRIPTION
Related to https://github.com/Tribler/tribler/issues/8511

I didn't locally build this because `flatpak-builder` broke on my system.

_EDIT:_ Verified on affected platform Linux Mint: this resolves the write permissions to `~/.Tribler`.