### PR TITLE
Added Notifications talk permission

### DIFF
--- a/org.tribler.Tribler.yaml
+++ b/org.tribler.Tribler.yaml
@@ -19,6 +19,7 @@ finish-args:
   - --filesystem=xdg-download                           # Store downloads in the user's download folder
   - --persist=.Tribler                                  # Store the application state
   - --talk-name=org.kde.StatusNotifierWatcher           # Used for AppIndicator support
+  - --talk-name=org.freedesktop.Notifications           # Used for D-Bus support
   - --env=SSL_CERT_DIR=/etc/ssl/certs
 modules:
   - shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json


### PR DESCRIPTION
fixes https://github.com/Tribler/tribler/issues/8883

---

Currrently, running the Flatpak logs this error on shutdown:

```
Exception in thread Thread-1 (run):
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/threading.py", line 1012, in run
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/pystray/_base.py", line 212, in run
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/pystray/_util/gtk.py", line 78, in _run
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/pystray/_appindicator.py", line 85, in _finalize
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/pystray/_util/gtk.py", line 159, in _finalize
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/pystray/_util/notify_dbus.py", line 92, in hide
gi.repository.GLib.GError: g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown (2)
```

In https://github.com/Tribler/tribler/issues/8883, I traced this back to the D-Bus `CloseNotification`, which requires the `Notifications` talk name/permission in Flatpak. Running with `org.freedesktop.Notifications` fixes the issue.